### PR TITLE
fix link to »GCP (Container) Structure Test«

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # structure-test-examples
 
-This repo contains a basic example of using the [GCP Structure Tests](https://github.com/GoogleCloudPlatform/runtimes-common/tree/master/structure_tests)
+This repo contains a basic example of using the [GCP Container Structure Tests](https://github.com/GoogleCloudPlatform/container-structure-test)
 
 To use, first run the `setup.sh` script to retrieve the correct binary, add to your system path, and pull the test image. Then, run the `run.sh` script in the `python` directory to run example tests on the Google App Engine Python image.
 


### PR DESCRIPTION
The repository for »GCP (Container) Structure Test« has changed to a
dedicated one, fixes the link within `README.md`.

Fixes #1.